### PR TITLE
fix: remove svelte linter warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sveltekit",
+    "name": "UP CSI App",
     "version": "0.0.0",
     "type": "module",
     "private": true,
@@ -19,13 +19,13 @@
     },
     "dependencies": {
         "@sveltejs/kit": "^2.17.3",
-        "lucide-svelte": "^0.485.0",
         "svelte": "^5.21.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@linthtml/linthtml": "^0.10.1",
         "@linthtml/linthtml-config-recommended": "^0.1.0",
+        "@lucide/svelte": "^0.487.0",
         "@sveltejs/adapter-static": "^3.0.8",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@tailwindcss/vite": "^4.0.9",
@@ -45,7 +45,7 @@
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.0",
         "typescript-svelte-plugin": "^0.3.45",
-        "vite": "^6.2.0"
+        "vite": ">=6.2.4"
     },
     "pnpm": {
         "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ onlyBuiltDependencies:
 dependencies:
   '@sveltejs/kit':
     specifier: ^2.17.3
-    version: 2.20.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.2)
+    version: 2.20.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.4)
   svelte:
     specifier: ^5.21.0
     version: 5.23.2
@@ -25,15 +25,18 @@ devDependencies:
   '@linthtml/linthtml-config-recommended':
     specifier: ^0.1.0
     version: 0.1.0(@linthtml/linthtml@0.10.1)
+  '@lucide/svelte':
+    specifier: ^0.487.0
+    version: 0.487.0(svelte@5.23.2)
   '@sveltejs/adapter-static':
     specifier: ^3.0.8
     version: 3.0.8(@sveltejs/kit@2.20.1)
   '@sveltejs/vite-plugin-svelte':
     specifier: ^5.0.3
-    version: 5.0.3(svelte@5.23.2)(vite@6.2.2)
+    version: 5.0.3(svelte@5.23.2)(vite@6.2.4)
   '@tailwindcss/vite':
     specifier: ^4.0.9
-    version: 4.0.14(vite@6.2.2)
+    version: 4.0.14(vite@6.2.4)
   eslint:
     specifier: ^9.21.0
     version: 9.22.0
@@ -83,8 +86,8 @@ devDependencies:
     specifier: ^0.3.45
     version: 0.3.46(svelte@5.23.2)(typescript@5.8.2)
   vite:
-    specifier: ^6.2.0
-    version: 6.2.2
+    specifier: '>=6.2.4'
+    version: 6.2.4
 
 packages:
 
@@ -524,6 +527,14 @@ packages:
       - typescript
     dev: true
 
+  /@lucide/svelte@0.487.0(svelte@5.23.2):
+    resolution: {integrity: sha512-27b/wUzWrqDJu97+1iSV2X8L2JGRWH/mAWAjHgazWxhGxVu/kS0p3SbNu6w3skNmQNEku33EKU1v44IVwULzbw==}
+    peerDependencies:
+      svelte: ^5
+    dependencies:
+      svelte: 5.23.2
+    dev: true
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -674,10 +685,10 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.20.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.2)
+      '@sveltejs/kit': 2.20.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.4)
     dev: true
 
-  /@sveltejs/kit@2.20.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.2):
+  /@sveltejs/kit@2.20.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.4):
     resolution: {integrity: sha512-XXd6hQKi9le+8rYIKsxTfgABjB3b8S21qZmMUTvAC5kuVA1AXvYPVEmxrMhRqyOacXu3e6P3ag5HtJi6j9K7UQ==}
     engines: {node: '>=18.13'}
     hasBin: true
@@ -686,7 +697,7 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.3 || ^6.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.23.2)(vite@6.2.2)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.23.2)(vite@6.2.4)
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -699,9 +710,9 @@ packages:
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
       svelte: 5.23.2
-      vite: 6.2.2
+      vite: 6.2.4
 
-  /@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.2):
+  /@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.4):
     resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
@@ -709,28 +720,28 @@ packages:
       svelte: ^5.0.0
       vite: ^6.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.23.2)(vite@6.2.2)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.23.2)(vite@6.2.4)
       debug: 4.4.0
       svelte: 5.23.2
-      vite: 6.2.2
+      vite: 6.2.4
     transitivePeerDependencies:
       - supports-color
 
-  /@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.23.2)(vite@6.2.2):
+  /@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.23.2)(vite@6.2.4):
     resolution: {integrity: sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
       svelte: ^5.0.0
       vite: ^6.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.2)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.23.2)(vite@6.2.4)
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.23.2
-      vite: 6.2.2
-      vitefu: 1.0.6(vite@6.2.2)
+      vite: 6.2.4
+      vitefu: 1.0.6(vite@6.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -847,7 +858,7 @@ packages:
       '@tailwindcss/oxide-win32-x64-msvc': 4.0.14
     dev: true
 
-  /@tailwindcss/vite@4.0.14(vite@6.2.2):
+  /@tailwindcss/vite@4.0.14(vite@6.2.4):
     resolution: {integrity: sha512-y69ztPTRFy+13EPS/7dEFVl7q2Goh1pQueVO8IfGeyqSpcx/joNJXFk0lLhMgUbF0VFJotwRSb9ZY7Xoq3r26Q==}
     peerDependencies:
       vite: ^5.2.0 || ^6
@@ -856,7 +867,7 @@ packages:
       '@tailwindcss/oxide': 4.0.14
       lightningcss: 1.29.2
       tailwindcss: 4.0.14
-      vite: 6.2.2
+      vite: 6.2.4
     dev: true
 
   /@types/cookie@0.6.0:
@@ -3303,8 +3314,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite@6.2.2:
-    resolution: {integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==}
+  /vite@6.2.4:
+    resolution: {integrity: sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -3349,7 +3360,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vitefu@1.0.6(vite@6.2.2):
+  /vitefu@1.0.6(vite@6.2.4):
     resolution: {integrity: sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
@@ -3357,7 +3368,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 6.2.2
+      vite: 6.2.4
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}

--- a/src/routes/NavBar.svelte
+++ b/src/routes/NavBar.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { BookCheck, CircleUserRound, LayoutDashboard, LogOut, NotebookPen } from 'lucide-svelte';
+    import { BookCheck, CircleUserRound, LayoutDashboard, LogOut, NotebookPen } from '@lucide/svelte';
     import CSI_Logo from '$lib/icons/upcsi.svg';
     import { page } from '$app/state';
     const options = ['Profile', 'Dashboard', 'Signature Sheet', 'Constitution Quiz'];

--- a/src/routes/consti-quiz/+page.svelte
+++ b/src/routes/consti-quiz/+page.svelte
@@ -19,22 +19,22 @@
         <!-- Nav Items -->
         <ul class="flex-grow space-y-2 text-xl">
             <li>
-                <a href="#" class="block rounded px-4 py-2 text-[#5A5A5D]">Profile</a>
+                <a href="#test" class="block rounded px-4 py-2 text-[#5A5A5D]">Profile</a>
             </li>
             <li>
-                <a href="#" class="block rounded px-4 py-2 text-[#5A5A5D]">Dashboard</a>
+                <a href="#test" class="block rounded px-4 py-2 text-[#5A5A5D]">Dashboard</a>
             </li>
             <li>
-                <a href="#" class="block rounded px-4 py-2 text-[#5A5A5D]">Signature Sheet</a>
+                <a href="#test" class="block rounded px-4 py-2 text-[#5A5A5D]">Signature Sheet</a>
             </li>
             <li>
-                <a href="#" class="block rounded px-4 py-2">Constitution Quiz</a>
+                <a href="#test" class="block rounded px-4 py-2">Constitution Quiz</a>
             </li>
         </ul>
 
         <!-- Logout -->
         <div>
-            <a href="#" class="block rounded px-4 py-2">Log out</a>
+            <a href="#test" class="block rounded px-4 py-2">Log out</a>
         </div>
     </nav>
 

--- a/src/routes/consti-quiz/+page.svelte
+++ b/src/routes/consti-quiz/+page.svelte
@@ -35,7 +35,7 @@
         <!-- Logout -->
         <div>
             <!-- for now, let's use a placeholder href to be changed later -->
-            <a href="/dashboard" class="block rounded px-4 py-2">Log out</a>
+            <a href="/" class="block rounded px-4 py-2">Log out</a>
         </div>
     </nav>
 

--- a/src/routes/consti-quiz/+page.svelte
+++ b/src/routes/consti-quiz/+page.svelte
@@ -19,22 +19,23 @@
         <!-- Nav Items -->
         <ul class="flex-grow space-y-2 text-xl">
             <li>
-                <a href="#test" class="block rounded px-4 py-2 text-[#5A5A5D]">Profile</a>
+                <a href="/sigsheet" class="block rounded px-4 py-2 text-[#5A5A5D]">Profile</a>
             </li>
             <li>
-                <a href="#test" class="block rounded px-4 py-2 text-[#5A5A5D]">Dashboard</a>
+                <a href="/" class="block rounded px-4 py-2 text-[#5A5A5D]">Dashboard</a>
             </li>
             <li>
-                <a href="#test" class="block rounded px-4 py-2 text-[#5A5A5D]">Signature Sheet</a>
+                <a href="/sigsheet" class="block rounded px-4 py-2 text-[#5A5A5D]">Signature Sheet</a>
             </li>
             <li>
-                <a href="#test" class="block rounded px-4 py-2">Constitution Quiz</a>
+                <a href="/consti-quiz" class="block rounded px-4 py-2">Constitution Quiz</a>
             </li>
         </ul>
 
         <!-- Logout -->
         <div>
-            <a href="#test" class="block rounded px-4 py-2">Log out</a>
+            <!-- for now, let's use a placeholder href to be changed later -->
+            <a href="/dashboard" class="block rounded px-4 py-2">Log out</a>
         </div>
     </nav>
 

--- a/src/routes/consti-quiz/SectionNav.svelte
+++ b/src/routes/consti-quiz/SectionNav.svelte
@@ -30,7 +30,7 @@
     <h2 class="mb-6 text-2xl font-bold text-white">Quiz Navigation</h2>
     {#each sections as section, index (index)}
         <div class="mb-2">
-            <div
+            <button
                 on:click={() => toggleSection(index)}
                 class="flex items-center justify-between rounded p-4 text-lg text-[#00C6D7]
 				       {section.subItems.length > 0 ? 'cursor-pointer hover:bg-[#2C2C2F]' : 'cursor-default'} 
@@ -68,13 +68,13 @@
                         </svg>
                     {/if}
                 {/if}
-            </div>
+            </button>
 
             {#if section.subItems.length > 0 && openSection === index}
                 <div class="mt-2 ml-6 space-y-2">
                     {#each section.subItems as subItem (subItem)}
                         <a
-                            href="#"
+                            href="#test"
                             class="block rounded px-4 py-3 text-lg text-gray-300 transition-colors duration-200 hover:bg-[#2C2C2F] hover:text-white"
                         >
                             {subItem}


### PR DESCRIPTION
This PR removes all the major warnings given by the Svelte linter. Additionally, it also updates vite to version numbers greater than or equal to `6.2.4` to avoid moderate security risks provided by dependabot.