### PR TITLE
fix(login): UP-Mail access only and login error page has dedciated content

### DIFF
--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -6,7 +6,7 @@ export const actions: Actions = {
         const { data, error } = await supabase.auth.signInWithOAuth({
             provider: 'google',
             options: {
-                redirectTo: 'http://localhost:5173/login/callback',
+                redirectTo: 'http://localhost:5173/login/callback', //Change this 
                 queryParams: {
                     access_type: 'offline',
                     prompt: 'consent',
@@ -15,7 +15,7 @@ export const actions: Actions = {
         });
 
         if (error) {
-            redirect(303, 'login/error');
+            redirect(303, `login/error?code=oauth_failed`);
         }
 
         if (data.url) {
@@ -23,3 +23,6 @@ export const actions: Actions = {
         }
     },
 };
+
+
+

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -6,7 +6,7 @@ export const actions: Actions = {
         const { data, error } = await supabase.auth.signInWithOAuth({
             provider: 'google',
             options: {
-                redirectTo: 'http://localhost:5173/login/callback', //Change this 
+                redirectTo: 'http://localhost:5173/login/callback', //Change this
                 queryParams: {
                     access_type: 'offline',
                     prompt: 'consent',
@@ -23,6 +23,3 @@ export const actions: Actions = {
         }
     },
 };
-
-
-

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -6,7 +6,7 @@ export const actions: Actions = {
         const { data, error } = await supabase.auth.signInWithOAuth({
             provider: 'google',
             options: {
-                redirectTo: 'http://localhost:5173/login/callback', //Change this
+                redirectTo: 'http://localhost:5173/login/callback', // Change this when prod
                 queryParams: {
                     access_type: 'offline',
                     prompt: 'consent',

--- a/src/routes/login/callback/+server.js
+++ b/src/routes/login/callback/+server.js
@@ -7,22 +7,25 @@ export const GET = async ({ url, locals: { supabase } }) => {
     if (code) {
         const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
         if (exchangeError) {
-            console.error('Code exchange failed:', exchangeError.message)
+            console.error('Code exchange failed:', exchangeError.message);
         }
-        
-        const { data: {user}, error: userError } = await supabase.auth.getUser();
+
+        const {
+            data: { user },
+            error: userError,
+        } = await supabase.auth.getUser();
         if (userError || !user) {
-            console.error('Failed to get user:', userError?.message);  
+            console.error('Failed to get user:', userError?.message);
             throw redirect(303, '/login/error?code=no_user');
         }
-        
-        if (!user.email?.endsWith('@up.edu.ph')){
+
+        if (!user.email?.endsWith('@up.edu.ph')) {
             await supabase.auth.signOut();
-            
+
             throw redirect(303, `/login/error?code=domain_restricted`);
         }
 
-        //Whitelist CSI Members, placeholder code 
+        //Whitelist CSI Members, placeholder code
         // const allowedEmails = [
         //     "cssacles@up.edu.ph",
         // ]
@@ -34,7 +37,7 @@ export const GET = async ({ url, locals: { supabase } }) => {
 
         throw redirect(303, `/${next.slice(1)}`);
     }
-    
+
     // return the user to an error page with instructions
     throw redirect(303, '/login/error?code=invalid_callback');
 };

--- a/src/routes/login/callback/+server.js
+++ b/src/routes/login/callback/+server.js
@@ -1,16 +1,40 @@
-import { redirect } from '@sveltejs/kit';
+import { redirect, error } from '@sveltejs/kit';
 
 export const GET = async ({ url, locals: { supabase } }) => {
     const code = url.searchParams.get('code');
     const next = url.searchParams.get('next') ?? '/';
 
     if (code) {
-        const { error } = await supabase.auth.exchangeCodeForSession(code);
-        if (!error) {
-            throw redirect(303, `/${next.slice(1)}`);
+        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
+        if (exchangeError) {
+            console.error('Code exchange failed:', exchangeError.message)
         }
-    }
+        
+        const { data: {user}, error: userError } = await supabase.auth.getUser();
+        if (userError || !user) {
+            console.error('Failed to get user:', userError?.message);  
+            throw redirect(303, '/login/error?code=no_user');
+        }
+        
+        if (!user.email?.endsWith('@up.edu.ph')){
+            await supabase.auth.signOut();
+            
+            throw redirect(303, `/login/error?code=domain_restricted`);
+        }
 
+        //Whitelist CSI Members, placeholder code 
+        // const allowedEmails = [
+        //     "cssacles@up.edu.ph",
+        // ]
+
+        // if(!allowedEmails.includes(user.email)){
+        //     await supabase.auth.signOut();
+        //     throw redirect(303, `/login/error?code=non_CSI`)
+        // }
+
+        throw redirect(303, `/${next.slice(1)}`);
+    }
+    
     // return the user to an error page with instructions
-    redirect(303, '/login/error');
+    throw redirect(303, '/login/error?code=invalid_callback');
 };

--- a/src/routes/login/callback/+server.js
+++ b/src/routes/login/callback/+server.js
@@ -1,4 +1,4 @@
-import { redirect, error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 export const GET = async ({ url, locals: { supabase } }) => {
     const code = url.searchParams.get('code');
@@ -25,7 +25,7 @@ export const GET = async ({ url, locals: { supabase } }) => {
             throw redirect(303, `/login/error?code=domain_restricted`);
         }
 
-        //Whitelist CSI Members, placeholder code
+        // Whitelist CSI Members, placeholder code
         // const allowedEmails = [
         //     "cssacles@up.edu.ph",
         // ]

--- a/src/routes/login/error/+page.svelte
+++ b/src/routes/login/error/+page.svelte
@@ -1,1 +1,29 @@
-<p>Login Error!!!</p>
+<script>
+    import logo from '$lib/icons/upcsi.svg';
+    let { data } = $props();
+    const errorMessage = data.message 
+</script>
+
+<div
+    class="font-inter flex min-h-screen w-full flex-col items-center justify-center gap-4 border text-center dark:bg-[#161619]"
+>
+    <h1 class="dark:text-csi-white text-4xl font-extrabold">Log In Failed!</h1>
+    <main
+    class="font-inter flex flex-col items-center justify-center gap-2 rounded-xl px-4 py-6 md:px-8 dark:bg-[#2f2f32]"
+    >
+    <div class="text-csi-blue mb-4 flex items-center justify-center gap-4">
+        <img src={logo} class="w-[25px]" alt="CSI Logo" />
+        <div class="font-inter flex flex-col text-left">
+            <span class="text-xs font-extralight">University of the Philippines</span>
+            <span class="mt-[-2px] text-xs font-semibold">Center for Student Innovations</span>
+        </div>
+    </div>
+    
+    <p class="dark:text-csi-white mb-2 text-xl">{errorMessage}</p>
+        <a
+            href="/login"
+            class="bg-csi-blue text-csi-black rounded-full px-4 py-2 text-sm font-bold underline hover:cursor-pointer"
+            >Go back to login page
+       </a>
+    </main>
+</div>

--- a/src/routes/login/error/+page.svelte
+++ b/src/routes/login/error/+page.svelte
@@ -1,7 +1,7 @@
 <script>
     import logo from '$lib/icons/upcsi.svg';
-    let { data } = $props();
-    const errorMessage = data.message 
+    const { data } = $props();
+    const errorMessage = data.message;
 </script>
 
 <div
@@ -9,21 +9,21 @@
 >
     <h1 class="dark:text-csi-white text-4xl font-extrabold">Log In Failed!</h1>
     <main
-    class="font-inter flex flex-col items-center justify-center gap-2 rounded-xl px-4 py-6 md:px-8 dark:bg-[#2f2f32]"
+        class="font-inter flex flex-col items-center justify-center gap-2 rounded-xl px-4 py-6 md:px-8 dark:bg-[#2f2f32]"
     >
-    <div class="text-csi-blue mb-4 flex items-center justify-center gap-4">
-        <img src={logo} class="w-[25px]" alt="CSI Logo" />
-        <div class="font-inter flex flex-col text-left">
-            <span class="text-xs font-extralight">University of the Philippines</span>
-            <span class="mt-[-2px] text-xs font-semibold">Center for Student Innovations</span>
+        <div class="text-csi-blue mb-4 flex items-center justify-center gap-4">
+            <img src={logo} class="w-[25px]" alt="CSI Logo" />
+            <div class="font-inter flex flex-col text-left">
+                <span class="text-xs font-extralight">University of the Philippines</span>
+                <span class="mt-[-2px] text-xs font-semibold">Center for Student Innovations</span>
+            </div>
         </div>
-    </div>
-    
-    <p class="dark:text-csi-white mb-2 text-xl">{errorMessage}</p>
+
+        <p class="dark:text-csi-white mb-2 text-xl">{errorMessage}</p>
         <a
             href="/login"
             class="bg-csi-blue text-csi-black rounded-full px-4 py-2 text-sm font-bold underline hover:cursor-pointer"
             >Go back to login page
-       </a>
+        </a>
     </main>
 </div>

--- a/src/routes/login/error/+page.ts
+++ b/src/routes/login/error/+page.ts
@@ -1,0 +1,15 @@
+const errorMessages: Record<string, string> = {
+    oauth_failed: "We couldn't complete your login with Google",
+    domain_restricted: "Only UP-Mail based accounts are allowed",
+    no_user: "Could not retrieve your account. Please try again.", 
+    non_CSI: "Invalid login, not affiliated with UP CSI",
+    invalid_callback: "Invalid login attempt. Please try again.",
+    unknown: "An unknown error occured. Please try again.",
+}
+
+
+export const load = ({ url }) => {
+    const code = url.searchParams.get('code') ?? 'unknown';
+    const message = errorMessages[code] ?? errorMessages.unknown
+    return { message }
+}

--- a/src/routes/login/error/+page.ts
+++ b/src/routes/login/error/+page.ts
@@ -1,15 +1,14 @@
 const errorMessages: Record<string, string> = {
     oauth_failed: "We couldn't complete your login with Google",
-    domain_restricted: "Only UP-Mail based accounts are allowed",
-    no_user: "Could not retrieve your account. Please try again.", 
-    non_CSI: "Invalid login, not affiliated with UP CSI",
-    invalid_callback: "Invalid login attempt. Please try again.",
-    unknown: "An unknown error occured. Please try again.",
-}
-
+    domain_restricted: 'Only UP-Mail based accounts are allowed',
+    no_user: 'Could not retrieve your account. Please try again.',
+    non_CSI: 'Invalid login, not affiliated with UP CSI',
+    invalid_callback: 'Invalid login attempt. Please try again.',
+    unknown: 'An unknown error occured. Please try again.',
+};
 
 export const load = ({ url }) => {
     const code = url.searchParams.get('code') ?? 'unknown';
-    const message = errorMessages[code] ?? errorMessages.unknown
-    return { message }
-}
+    const message = errorMessages[code] ?? errorMessages.unknown;
+    return { message };
+};


### PR DESCRIPTION
Implemented the requested bug fixes for the login page, specifically:

1. Error page has placeholder content - Already added a dedicated error page with styles and a dynamic errror message depending the cause of the error (e.g non-up mail, auth failed, etc.)

2. Any email can be used to login - Web App throws an error if a non-up email is used to log in. Currently up-mail based accounts can login, but added a logic for whitelisting the login to CSI apps/mems. 

Additional Notes:
- Will update to whitelisting accordingly once a new table for whitelist is established. 
- Change domain name via Google Cloud Console (Auth) once ready to deploy