### PR TITLE
fix(dashboard): update consti quiz deadline in dashboard, update consti copy

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -133,7 +133,7 @@
     const quizRawStart = new Date(2025, 9, 27, 0, 0, 0);
     const quizRawEnd = new Date(2025, 10, 1, 23, 59, 59);
     if (quizRawEnd.getTime() <= quizRawStart.getTime()) {
-        throw new Error("Consti quiz end time is on or before start time");
+        throw new Error('Consti quiz end time is on or before start time');
     }
 
     let daysLeft = 0;
@@ -150,11 +150,11 @@
         hoursLeft = Math.floor((timeLeft % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
 
         if (now.getTime() - quizRawStart.getTime() < 0) {
-            quizClosingString = `The quiz will open on ${quizRawStart.toLocaleDateString("en-us", {month: "long"})} ${quizRawStart.getDate()}, ${quizRawStart.getFullYear()} at ${quizRawStart.toLocaleTimeString("en-us", {hour: "numeric", minute: "numeric"})}.`;
+            quizClosingString = `The quiz will open on ${quizRawStart.toLocaleDateString('en-us', { month: 'long' })} ${quizRawStart.getDate()}, ${quizRawStart.getFullYear()} at ${quizRawStart.toLocaleTimeString('en-us', { hour: 'numeric', minute: 'numeric' })}.`;
         } else if (timeLeft < 0) {
             quizClosingString = 'The quiz has closed.';
         } else if (daysLeft < 1 && hoursLeft < 1) {
-            quizClosingString = `The quiz will close at ${quizRawEnd.toLocaleTimeString("en-us", {hour: "numeric", minute: "numeric"})}.`;
+            quizClosingString = `The quiz will close at ${quizRawEnd.toLocaleTimeString('en-us', { hour: 'numeric', minute: 'numeric' })}.`;
         } else {
             const daysString = `${daysLeft}${daysLeft === 1 ? ' day' : ' days'}`;
             const hoursString = `${hoursLeft}${hoursLeft === 1 ? ' hour' : ' hours'}`;
@@ -220,18 +220,25 @@
                             or members!
                         </li>
                         <li class="py-1">
-                            The consti quiz is open from <b>{quizRawStart.toLocaleDateString("en-us", {month: "short"})} {quizRawStart.getDate()} ({quizRawStart.toLocaleDateString("en-us", {weekday: "short"})}) to {quizRawEnd.toLocaleDateString("en-us", {month: "short"})} {quizRawEnd.getDate()} ({quizRawEnd.toLocaleDateString("en-us", {weekday: "short"})})</b>. Your progress will be saved when you
-                            exit.
+                            The consti quiz is open from <b
+                                >{quizRawStart.toLocaleDateString('en-us', { month: 'short' })}
+                                {quizRawStart.getDate()} ({quizRawStart.toLocaleDateString('en-us', {
+                                    weekday: 'short',
+                                })}) to {quizRawEnd.toLocaleDateString('en-us', { month: 'short' })}
+                                {quizRawEnd.getDate()} ({quizRawEnd.toLocaleDateString('en-us', {
+                                    weekday: 'short',
+                                })})</b
+                            >. Your progress will be saved when you exit.
                         </li>
                     </ul>
                 </div>
 
-                {#if new Date().getTime() >= quizRawStart.getTime() && (new Date().getTime()) <= quizRawEnd.getTime()}
-                <a
-                    href="./consti-quiz"
-                    class="bg-csi-blue w-1/4 self-center rounded-3xl py-2 text-center font-bold text-[#161619]"
-                    >Continue</a
-                >
+                {#if new Date().getTime() >= quizRawStart.getTime() && new Date().getTime() <= quizRawEnd.getTime()}
+                    <a
+                        href="./consti-quiz"
+                        class="bg-csi-blue w-1/4 self-center rounded-3xl py-2 text-center font-bold text-[#161619]"
+                        >Continue</a
+                    >
                 {/if}
             </div>
         </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,28 +129,32 @@
     import logo from '$lib/icons/upcsi.svg';
 
     // take note month starts at 0
-    // sample deadline is May 31, 6:30 PM
-    const quizRawDeadline = new Date(2025, 4, 31, 18, 30, 0);
-    const deadlineHour = quizRawDeadline.getHours();
-    const deadlineMinutes = quizRawDeadline.getMinutes();
-    const quizDeadline = quizRawDeadline.getTime();
+    // planned duration of consti quiz is from Oct 27 (12 AM) to Nov 1 (11:59 PM)
+    const quizRawStart = new Date(2025, 9, 27, 0, 0, 0);
+    const quizRawEnd = new Date(2025, 10, 1, 23, 59, 59);
+    if (quizRawEnd.getTime() <= quizRawStart.getTime()) {
+        throw new Error("Consti quiz end time is on or before start time");
+    }
+
     let daysLeft = 0;
     let hoursLeft = 0;
     let quizClosingString = $state('');
 
     function updateTimeLeft() {
-        const now = new Date().getTime();
+        const now = new Date();
         // console.log(now);
 
-        const timeLeft = quizDeadline - now;
+        const timeLeft = quizRawEnd.getTime() - now.getTime();
 
         daysLeft = Math.floor(timeLeft / (1000 * 60 * 60 * 24));
         hoursLeft = Math.floor((timeLeft % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
 
-        if (timeLeft < 0) {
+        if (now.getTime() - quizRawStart.getTime() < 0) {
+            quizClosingString = `The quiz will open on ${quizRawStart.toLocaleDateString("en-us", {month: "long"})} ${quizRawStart.getDate()}, ${quizRawStart.getFullYear()} at ${quizRawStart.toLocaleTimeString("en-us", {hour: "numeric", minute: "numeric"})}.`;
+        } else if (timeLeft < 0) {
             quizClosingString = 'The quiz has closed.';
         } else if (daysLeft < 1 && hoursLeft < 1) {
-            quizClosingString = `The quiz will close at ${deadlineHour % 12}:${(deadlineMinutes < 10 ? '0' : '') + deadlineMinutes} ${deadlineHour >= 12 ? 'PM' : 'AM'}.`;
+            quizClosingString = `The quiz will close at ${quizRawEnd.toLocaleTimeString("en-us", {hour: "numeric", minute: "numeric"})}.`;
         } else {
             const daysString = `${daysLeft}${daysLeft === 1 ? ' day' : ' days'}`;
             const hoursString = `${hoursLeft}${hoursLeft === 1 ? ' hour' : ' hours'}`;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -207,7 +207,7 @@
                         <li class="py-1">
                             This quiz is open notes and you may view a copy of the constitution <a
                                 class="text-csi-blue hover:underline hover:duration-300 hover:ease-in-out"
-                                href="https://drive.google.com/file/d/1p9rVCCyIwaA7W36t_hbwF9-lFWSJ3NR-/view?usp=drive_link"
+                                href="https://drive.google.com/file/d/1JtbGcts8YKyJsm20wgJh3I7Umwh0VwAz/view?usp=sharing"
                                 target="_blank">here</a
                             >.
                         </li>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -220,7 +220,7 @@
                             or members!
                         </li>
                         <li class="py-1">
-                            The deadline of the quiz is <b>May 31, 6:30 PM</b>. Your progress will be saved when you
+                            The consti quiz is open from <b>{quizRawStart.toLocaleDateString("en-us", {month: "short"})} {quizRawStart.getDate()} ({quizRawStart.toLocaleDateString("en-us", {weekday: "short"})}) to {quizRawEnd.toLocaleDateString("en-us", {month: "short"})} {quizRawEnd.getDate()} ({quizRawEnd.toLocaleDateString("en-us", {weekday: "short"})})</b>. Your progress will be saved when you
                             exit.
                         </li>
                     </ul>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -225,11 +225,14 @@
                         </li>
                     </ul>
                 </div>
+
+                {#if new Date().getTime() >= quizRawStart.getTime() && (new Date().getTime()) <= quizRawEnd.getTime()}
                 <a
                     href="./consti-quiz"
                     class="bg-csi-blue w-1/4 self-center rounded-3xl py-2 text-center font-bold text-[#161619]"
                     >Continue</a
                 >
+                {/if}
             </div>
         </main>
     </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -200,7 +200,7 @@
                     <p class="text-csi-white">{quizProgress}</p>
                 </div>
 
-                <div class="mt-1 h-4 w-full overflow-hidden rounded-full bg-gray-700">
+                <div class="h-6 w-full overflow-hidden rounded-full bg-gray-700">
                     <div class="h-full bg-cyan-400" style="width: {calculatePercentage(quizProgress)}%"></div>
                 </div>
                 <p class="text-csi-white">{quizClosingString}</p>


### PR DESCRIPTION
This PR fixes #31 and #32:
- The actual consti quiz duration is shown (Oct 27 to Nov 1)
- The consti quiz button only appears during that duration
- A message is displayed if the quiz is not yet open
- The constitution copy is now the 2025 version