### PR TITLE
feat(sigsheet): Applicant Folders in Google Drive

### DIFF
--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -1,9 +1,10 @@
 import { writable } from 'svelte/store';
 
 export const uuid = writable('');
+export const username = writable('');
 
-// export const gdrive_folder = writable('');
-export const gdrive_folder_id = '1caL05EFKPFVySv4slWpDJERlD6zRBPGW'; // TODO
+export const gdrive_folder_id = writable('');
+export const gdrive_root_folder = '1caL05EFKPFVySv4slWpDJERlD6zRBPGW'; 
 
 const store = writable(new Set());
 

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -4,7 +4,7 @@ export const uuid = writable('');
 export const username = writable('');
 
 export const gdrive_folder_id = writable('');
-export const gdrive_root_folder = '1caL05EFKPFVySv4slWpDJERlD6zRBPGW'; 
+export const gdrive_root_folder = '1caL05EFKPFVySv4slWpDJERlD6zRBPGW';
 
 const store = writable(new Set());
 

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -1,5 +1,9 @@
 import { writable } from 'svelte/store';
+
 export const uuid = writable('');
+
+// export const gdrive_folder = writable('');
+export const gdrive_folder_id = '1caL05EFKPFVySv4slWpDJERlD6zRBPGW'; // TODO
 
 const store = writable(new Set());
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -165,8 +165,12 @@
         username.set(data.user!.email!.split('@')[0] ?? '');
         console.log('UUID: ', $uuid);
         onMount(async () => {
-            await fetchSigsheet(data.user!.id);
-            await fetchFolder($uuid, $username);
+            if ($filledSigsheet.size === 0) {
+                await fetchSigsheet(data.user!.id);
+            }
+            if ($gdrive_folder_id === '') {
+                await fetchFolder($uuid, $username);
+            }
         });
     }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,13 +84,13 @@
         const memberData = supabaseMembers.data;
 
         const totalByCommittee: Record<string, number> = {
-            'Executive': 0,
+            Executive: 0,
             'Membership & Internals': 0,
-            'Service': 0,
-            'Innovation': 0,
-            'Engineering': 0,
+            Service: 0,
+            Innovation: 0,
+            Engineering: 0,
             'External Relations': 0,
-            'Branding & Creatives': 0
+            'Branding & Creatives': 0,
         };
         memberData.forEach((row: { member_committee: string }) => {
             const committee = row.member_committee;
@@ -106,8 +106,6 @@
                 color: committeeColors[name],
             };
         });
-
-        
     });
 
     const { data } = $props();
@@ -139,8 +137,8 @@
                 method: 'POST',
                 body: JSON.stringify({
                     uuid: applicant_id,
-                    username: username
-                })
+                    username: username,
+                }),
             });
 
             if (!response.ok) {
@@ -155,7 +153,7 @@
         } catch (error) {
             console.error('Unexpected error on fetchFolder():', error);
             alert('An unexpected error occurred. Please try again.');
-        }   
+        }
     }
 
     // Set up user variables in $lib

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,7 +83,15 @@
 
         const memberData = supabaseMembers.data;
 
-        const totalByCommittee: Record<string, number> = {};
+        const totalByCommittee: Record<string, number> = {
+            'Executive': 0,
+            'Membership & Internals': 0,
+            'Service': 0,
+            'Innovation': 0,
+            'Engineering': 0,
+            'External Relations': 0,
+            'Branding & Creatives': 0
+        };
         memberData.forEach((row: { member_committee: string }) => {
             const committee = row.member_committee;
             totalByCommittee[committee] = (totalByCommittee[committee] || 0) + 1;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { filledSigsheet, uuid } from '$lib/shared';
+    import { filledSigsheet, gdrive_folder_id, username, uuid } from '$lib/shared';
     import { onMount } from 'svelte';
     import { supabase } from '$lib/supabaseClient';
 
@@ -98,13 +98,18 @@
                 color: committeeColors[name],
             };
         });
+
+        
     });
 
     const { data } = $props();
-    async function fetchSigsheet(uuid: string) {
-        console.log('Fetching sigsheet from Supabase with ID:', uuid);
+    async function fetchSigsheet(applicant_id: string) {
+        console.log('Fetching sigsheet from Supabase with ID:', applicant_id);
         try {
-            const { data, error } = await supabase.from('sigsheet').select('member_id').eq('applicant_id', uuid);
+            const { data, error } = await supabase
+                .from('sigsheet')
+                .select('member_id')
+                .eq('applicant_id', applicant_id);
 
             if (error) {
                 console.error('Supabase error:', error);
@@ -119,11 +124,42 @@
         }
     }
 
-    console.log(data);
+    async function fetchFolder(applicant_id: string, username: string) {
+        console.log('Fetching gdrive_folder_id for Applicant:', applicant_id);
+        try {
+            const response = await fetch('/api/get_gdrive_folder', {
+                method: 'POST',
+                body: JSON.stringify({
+                    uuid: applicant_id,
+                    username: username
+                })
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                console.error('Error fetching Folder ID', error);
+            } else {
+                const data = await response.json();
+                console.log('Folder ID fetched successfully:', data);
+                gdrive_folder_id.set(data.folder_id);
+                console.log('$lib gdrive_folder_id set to', $gdrive_folder_id);
+            }
+        } catch (error) {
+            console.error('Unexpected error on fetchFolder():', error);
+            alert('An unexpected error occurred. Please try again.');
+        }   
+    }
+
+    // Set up user variables in $lib
     if (data !== null && data.user !== null) {
-        uuid.set(data.user.id);
+        console.log(data);
+        uuid.set(data.user!.id);
+        username.set(data.user!.email!.split('@')[0] ?? '');
         console.log('UUID: ', $uuid);
-        fetchSigsheet(data.user.id);
+        onMount(async () => {
+            await fetchSigsheet(data.user!.id);
+            await fetchFolder($uuid, $username);
+        });
     }
 
     import logo from '$lib/icons/upcsi.svg';

--- a/src/routes/api/get_gdrive_folder/+server.js
+++ b/src/routes/api/get_gdrive_folder/+server.js
@@ -13,34 +13,28 @@ export async function POST({ request }) {
     });
 
     try {
-        const { uuid, username } = await request.json()
+        const { uuid, username } = await request.json();
 
         // Ensure uuid is not empty
         if (uuid === '' || uuid === null) {
             console.error('Validation Error: $uuid is empty: ');
-            return new Response(
-                JSON.stringify({error: "UUID is empty."}),
-                {
-                    status: 400,
-                    headers: {'Content-Type': 'application/json'},
-                }
-            );
+            return new Response(JSON.stringify({ error: 'UUID is empty.' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
         }
-        console.log("$uuid is filled.");
+        console.log('$uuid is filled.');
 
         if (username === '' || username === null) {
             console.error('Validation Error: $username is empty: ');
-            return new Response(
-                JSON.stringify({error: "Username is empty."}),
-                {
-                    status: 400,
-                    headers: {'Content-Type': 'application/json'},
-                }
-            );
+            return new Response(JSON.stringify({ error: 'Username is empty.' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
         }
-        console.log("$username is filled.");
+        console.log('$username is filled.');
 
-        console.log("Authenticating into Google Drive.");
+        console.log('Authenticating into Google Drive.');
         // Authenticate with Google Drive API
         const auth = new google.auth.GoogleAuth({
             credentials: {
@@ -50,126 +44,112 @@ export async function POST({ request }) {
             scopes: ['https://www.googleapis.com/auth/drive'],
         });
         const drive = google.drive({ version: 'v3', auth });
-        console.log("Authenticated into Google Drive.");
+        console.log('Authenticated into Google Drive.');
 
         // Check if applicant already has a gdrive_folder
         try {
-            console.log("Searching for folder in Supabase.");
+            console.log('Searching for folder in Supabase.');
             const { data, error } = await supabase
                 .from('pic-folders')
                 .select('gdrive_folder')
                 .eq('applicant_uuid', uuid)
                 .single();
-            console.log("Done searching for folder in Supabase.");
+            console.log('Done searching for folder in Supabase.');
 
             // Error PGRST116: row not found; So throw unexpected error
             if (error && error.code !== 'PGRST116') {
                 console.error('Error reading from Supabase: ', error);
                 throw new Error(error.message);
             }
-        
+
             // If applicant has folder, return it
             if (data) {
                 console.log('Applicant does have folder:', data.gdrive_folder);
                 return new Response(
-                    JSON.stringify({ 
-                        message: "Applicant does have folder",
-                        folder_id: data.gdrive_folder 
+                    JSON.stringify({
+                        message: 'Applicant does have folder',
+                        folder_id: data.gdrive_folder,
                     }),
                     {
                         status: 200,
                         headers: { 'Content-Type': 'application/json' },
-                    }
+                    },
                 );
             }
         } catch (supabaseError) {
             console.error('Error reading from Supabase:', supabaseError);
-            return new Response(
-                JSON.stringify({ error: 'Error reading from Supabase' }),
-                {
-                    status: 500,
-                    headers: { 'Content-Type': 'application/json'}
-                }
-            );
+            return new Response(JSON.stringify({ error: 'Error reading from Supabase' }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+            });
         }
 
         // No folder exists, so create a new one in Google Drive
         const fileMetadata = {
             name: `${username}`,
             mimeType: 'application/vnd.google-apps.folder',
-            parents: [gdrive_root_folder]
+            parents: [gdrive_root_folder],
         };
-        
+
         let folder_id = null;
         try {
-            console.log("No folder exists for user.");
-            console.log("Creating new folder in Google Drive.");
+            console.log('No folder exists for user.');
+            console.log('Creating new folder in Google Drive.');
             const gdrive_folder = await drive.files.create({
                 requestBody: fileMetadata,
-                fields: 'id'
+                fields: 'id',
             });
             folder_id = gdrive_folder.data.id;
-            console.log("New folder created:", folder_id);
+            console.log('New folder created:', folder_id);
         } catch (driveError) {
             console.error('Error creating new folder in Google Drive:', {
-                message: driveError instanceof Error 
-                    ? driveError.message 
-                    : 'Unknown error',
-                errors: driveError instanceof Error && 'errors' in driveError 
-                    ? driveError.errors 
-                    : 'No additional error details',
-                stack: driveError instanceof Error
-                    ?driveError.stack
-                    :'No stack trace available'
+                message: driveError instanceof Error ? driveError.message : 'Unknown error',
+                errors:
+                    driveError instanceof Error && 'errors' in driveError
+                        ? driveError.errors
+                        : 'No additional error details',
+                stack: driveError instanceof Error ? driveError.stack : 'No stack trace available',
             });
         }
 
         try {
-            console.log("Inserting new folder into Supabase.");
+            console.log('Inserting new folder into Supabase.');
             const { data, error } = await supabase
                 .from('pic-folders')
                 .insert({
                     applicant_uuid: uuid,
-                    gdrive_folder: folder_id
+                    gdrive_folder: folder_id,
                 })
                 .select(); // makes Supabase return inserted rows
-            
+
             if (error) {
                 console.error('Error inserting folder into Supabase:', error);
                 throw new Error(error.message);
             }
 
-            console.log("Folder successfully inserted into Supabase");
+            console.log('Folder successfully inserted into Supabase');
             return new Response(
-                JSON.stringify({ 
-                    message: "Folder successfully inserted into Supabase",
-                    folder_id: data[0].gdrive_folder
+                JSON.stringify({
+                    message: 'Folder successfully inserted into Supabase',
+                    folder_id: data[0].gdrive_folder,
                 }),
                 {
-                   status: 200,
-                   headers: { 'Content-Type': 'application/json' } 
-                }
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                },
             );
         } catch (supabaseError) {
-            console.error("Error inserting to Supabase:", supabaseError);
-            return new Response(
-                JSON.stringify({ error: "Error inserting into Supabase" }),
-                {
-                    status: 500,
-                    headers: { 'Content-Type': 'application/json' }
-                }
-            );
+            console.error('Error inserting to Supabase:', supabaseError);
+            return new Response(JSON.stringify({ error: 'Error inserting into Supabase' }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+            });
         }
-
     } catch (err) {
         console.error('Unexpected Error: ', err);
-        return new Response(
-            JSON.stringify({ error: err instanceof Error ? err.message : 'Unknown error' }),
-            {
-                status: 500,
-                headers: { 'Content-Type': 'application/json'}
-            }
-        );
+        return new Response(JSON.stringify({ error: err instanceof Error ? err.message : 'Unknown error' }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+        });
     }
-    
 }

--- a/src/routes/api/get_gdrive_folder/+server.js
+++ b/src/routes/api/get_gdrive_folder/+server.js
@@ -1,0 +1,175 @@
+import { PUBLIC_GOOGLE_PRIVATE_KEY, PUBLIC_GOOGLE_SERVICE_EMAIL } from '$env/static/public';
+import { gdrive_root_folder } from '$lib/shared';
+import { google } from 'googleapis';
+import { supabase } from '$lib/supabaseClient';
+
+export async function POST({ request }) {
+    console.log('Received POST request at /api/get_gdrive_folder');
+
+    // Add debugging logs to verify environment variables
+    console.log('Google API Credentials:', {
+        client_email: PUBLIC_GOOGLE_SERVICE_EMAIL,
+        private_key: PUBLIC_GOOGLE_PRIVATE_KEY ? 'Provided' : ' Not Provided',
+    });
+
+    try {
+        const { uuid, username } = await request.json()
+
+        // Ensure uuid is not empty
+        if (uuid === '' || uuid === null) {
+            console.error('Validation Error: $uuid is empty: ');
+            return new Response(
+                JSON.stringify({error: "UUID is empty."}),
+                {
+                    status: 400,
+                    headers: {'Content-Type': 'application/json'},
+                }
+            );
+        }
+        console.log("$uuid is filled.");
+
+        if (username === '' || username === null) {
+            console.error('Validation Error: $username is empty: ');
+            return new Response(
+                JSON.stringify({error: "Username is empty."}),
+                {
+                    status: 400,
+                    headers: {'Content-Type': 'application/json'},
+                }
+            );
+        }
+        console.log("$username is filled.");
+
+        console.log("Authenticating into Google Drive.");
+        // Authenticate with Google Drive API
+        const auth = new google.auth.GoogleAuth({
+            credentials: {
+                client_email: PUBLIC_GOOGLE_SERVICE_EMAIL,
+                private_key: PUBLIC_GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+            },
+            scopes: ['https://www.googleapis.com/auth/drive'],
+        });
+        const drive = google.drive({ version: 'v3', auth });
+        console.log("Authenticated into Google Drive.");
+
+        // Check if applicant already has a gdrive_folder
+        try {
+            console.log("Searching for folder in Supabase.");
+            const { data, error } = await supabase
+                .from('pic-folders')
+                .select('gdrive_folder')
+                .eq('applicant_uuid', uuid)
+                .single();
+            console.log("Done searching for folder in Supabase.");
+
+            // Error PGRST116: row not found; So throw unexpected error
+            if (error && error.code !== 'PGRST116') {
+                console.error('Error reading from Supabase: ', error);
+                throw new Error(error.message);
+            }
+        
+            // If applicant has folder, return it
+            if (data) {
+                console.log('Applicant does have folder:', data.gdrive_folder);
+                return new Response(
+                    JSON.stringify({ 
+                        message: "Applicant does have folder",
+                        folder_id: data.gdrive_folder 
+                    }),
+                    {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    }
+                );
+            }
+        } catch (supabaseError) {
+            console.error('Error reading from Supabase:', supabaseError);
+            return new Response(
+                JSON.stringify({ error: 'Error reading from Supabase' }),
+                {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json'}
+                }
+            );
+        }
+
+        // No folder exists, so create a new one in Google Drive
+        const fileMetadata = {
+            name: `${username}`,
+            mimeType: 'application/vnd.google-apps.folder',
+            parents: [gdrive_root_folder]
+        };
+        
+        let folder_id = null;
+        try {
+            console.log("No folder exists for user.");
+            console.log("Creating new folder in Google Drive.");
+            const gdrive_folder = await drive.files.create({
+                requestBody: fileMetadata,
+                fields: 'id'
+            });
+            folder_id = gdrive_folder.data.id;
+            console.log("New folder created:", folder_id);
+        } catch (driveError) {
+            console.error('Error creating new folder in Google Drive:', {
+                message: driveError instanceof Error 
+                    ? driveError.message 
+                    : 'Unknown error',
+                errors: driveError instanceof Error && 'errors' in driveError 
+                    ? driveError.errors 
+                    : 'No additional error details',
+                stack: driveError instanceof Error
+                    ?driveError.stack
+                    :'No stack trace available'
+            });
+        }
+
+        try {
+            console.log("Inserting new folder into Supabase.");
+            const { data, error } = await supabase
+                .from('pic-folders')
+                .insert({
+                    applicant_uuid: uuid,
+                    gdrive_folder: folder_id
+                })
+                .select(); // makes Supabase return inserted rows
+            
+            if (error) {
+                console.error('Error inserting folder into Supabase:', error);
+                throw new Error(error.message);
+            }
+
+            console.log("Folder successfully inserted into Supabase");
+            return new Response(
+                JSON.stringify({ 
+                    message: "Folder successfully inserted into Supabase",
+                    folder_id: data[0].gdrive_folder
+                }),
+                {
+                   status: 200,
+                   headers: { 'Content-Type': 'application/json' } 
+                }
+            );
+        } catch (supabaseError) {
+            console.error("Error inserting to Supabase:", supabaseError);
+            return new Response(
+                JSON.stringify({ error: "Error inserting into Supabase" }),
+                {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' }
+                }
+            );
+        }
+
+    } catch (err) {
+        console.error('Unexpected Error: ', err);
+        return new Response(
+            JSON.stringify({ error: err instanceof Error ? err.message : 'Unknown error' }),
+            {
+                status: 500,
+                headers: { 'Content-Type': 'application/json'}
+            }
+        );
+    }
+    
+}

--- a/src/routes/api/upload/+server.js
+++ b/src/routes/api/upload/+server.js
@@ -1,6 +1,5 @@
 import { PUBLIC_GOOGLE_PRIVATE_KEY, PUBLIC_GOOGLE_SERVICE_EMAIL } from '$env/static/public';
 import { Readable } from 'stream';
-import { gdrive_folder_id } from '$lib/shared'; 
 import { google } from 'googleapis';
 import { supabase } from '../../../lib/supabaseClient';
 
@@ -13,16 +12,17 @@ export async function POST({ request }) {
         private_key: PUBLIC_GOOGLE_PRIVATE_KEY ? 'Provided' : 'Not Provided',
     });
 
-    // Add debugging logs to verify folder permissions
-    console.log('Google Drive Folder ID:', gdrive_folder_id);
-
     try {
         const formData = await request.formData();
         const uuid = formData.get('uuid');
+        const gdrive_folder_id = formData.get('gdrive_folder_id');
         const member_id = formData.get('member_id');
         const question = formData.get('question');
         const answer = formData.get('answer');
         const imageFile = formData.get('image');
+
+        // Add debugging logs to verify folder permissions
+        console.log('Google Drive Folder ID:', gdrive_folder_id);
 
         if (!question || !answer || !imageFile || !(imageFile instanceof File)) {
             console.error('Validation error: Missing or invalid required fields');
@@ -50,7 +50,7 @@ export async function POST({ request }) {
         // Upload image to Google Drive
         const fileMetadata = {
             name: imageFile.name,
-            parents: [gdrive_folder_id],
+            parents: [String(gdrive_folder_id)],
         };
 
         const media = {

--- a/src/routes/api/upload/+server.js
+++ b/src/routes/api/upload/+server.js
@@ -1,5 +1,6 @@
 import { PUBLIC_GOOGLE_PRIVATE_KEY, PUBLIC_GOOGLE_SERVICE_EMAIL } from '$env/static/public';
 import { Readable } from 'stream';
+import { gdrive_folder_id } from '$lib/shared'; 
 import { google } from 'googleapis';
 import { supabase } from '../../../lib/supabaseClient';
 
@@ -13,7 +14,7 @@ export async function POST({ request }) {
     });
 
     // Add debugging logs to verify folder permissions
-    console.log('Google Drive Folder ID:', '1caL05EFKPFVySv4slWpDJERlD6zRBPGW');
+    console.log('Google Drive Folder ID:', gdrive_folder_id);
 
     try {
         const formData = await request.formData();
@@ -49,7 +50,7 @@ export async function POST({ request }) {
         // Upload image to Google Drive
         const fileMetadata = {
             name: imageFile.name,
-            parents: ['1caL05EFKPFVySv4slWpDJERlD6zRBPGW'],
+            parents: [gdrive_folder_id],
         };
 
         const media = {

--- a/src/routes/api/upload/+server.js
+++ b/src/routes/api/upload/+server.js
@@ -51,7 +51,7 @@ export async function POST({ request }) {
 
         // Upload image to Google Drive
         const fileMetadata = {
-            name: `${String(username)}-${String(member_name).replace(/\s+/g, "")}`,
+            name: `${String(username)}-${String(member_name).replace(/\s+/g, '')}`,
             parents: [String(gdrive_folder_id)],
         };
 

--- a/src/routes/api/upload/+server.js
+++ b/src/routes/api/upload/+server.js
@@ -15,8 +15,10 @@ export async function POST({ request }) {
     try {
         const formData = await request.formData();
         const uuid = formData.get('uuid');
+        const username = formData.get('username');
         const gdrive_folder_id = formData.get('gdrive_folder_id');
         const member_id = formData.get('member_id');
+        const member_name = formData.get('member_name');
         const question = formData.get('question');
         const answer = formData.get('answer');
         const imageFile = formData.get('image');
@@ -49,7 +51,7 @@ export async function POST({ request }) {
 
         // Upload image to Google Drive
         const fileMetadata = {
-            name: imageFile.name,
+            name: `${String(username)}-${String(member_name).replace(/\s+/g, "")}`,
             parents: [String(gdrive_folder_id)],
         };
 

--- a/src/routes/sigsheet/Modal.svelte
+++ b/src/routes/sigsheet/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { filledSigsheet, gdrive_folder_id, uuid } from '$lib/shared';
+    import { filledSigsheet, gdrive_folder_id, username, uuid } from '$lib/shared';
     import { writable } from 'svelte/store';
 
     const { member_id, name, role, closeModal, activeCategory } = $props();
@@ -75,10 +75,12 @@
     </div>
 
     <form class="grid gap-6 md:grid-cols-2 md:gap-0" onsubmit={handleSubmit}>
-        <input type="text" alt="uuid" id="uuid-input" name="uuid" value={$uuid} hidden required />
         <input type="text" alt="gdrive_folder_id" id="gdrive_folder_id-input" name="gdrive_folder_id" value={$gdrive_folder_id} hidden required />
-
         <input type="text" alt="member_id" id="memberid-input" name="member_id" value={member_id} hidden required />
+        <input type="text" alt="member_name" id="membername-input" name="member_name" value={name} hidden required />
+        <input type="text" alt="username" id="username-input" name="username" value={$username} hidden required />
+        <input type="text" alt="uuid" id="uuid-input" name="uuid" value={$uuid} hidden required />
+        
 
         <div class="mx-10 md:mr-3">
             <h2 class="pb-1 text-4xl font-bold" style="color:{categoryColors[activeCategory]}">{name}</h2>

--- a/src/routes/sigsheet/Modal.svelte
+++ b/src/routes/sigsheet/Modal.svelte
@@ -75,12 +75,19 @@
     </div>
 
     <form class="grid gap-6 md:grid-cols-2 md:gap-0" onsubmit={handleSubmit}>
-        <input type="text" alt="gdrive_folder_id" id="gdrive_folder_id-input" name="gdrive_folder_id" value={$gdrive_folder_id} hidden required />
+        <input
+            type="text"
+            alt="gdrive_folder_id"
+            id="gdrive_folder_id-input"
+            name="gdrive_folder_id"
+            value={$gdrive_folder_id}
+            hidden
+            required
+        />
         <input type="text" alt="member_id" id="memberid-input" name="member_id" value={member_id} hidden required />
         <input type="text" alt="member_name" id="membername-input" name="member_name" value={name} hidden required />
         <input type="text" alt="username" id="username-input" name="username" value={$username} hidden required />
         <input type="text" alt="uuid" id="uuid-input" name="uuid" value={$uuid} hidden required />
-        
 
         <div class="mx-10 md:mr-3">
             <h2 class="pb-1 text-4xl font-bold" style="color:{categoryColors[activeCategory]}">{name}</h2>

--- a/src/routes/sigsheet/Modal.svelte
+++ b/src/routes/sigsheet/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { filledSigsheet, uuid } from '$lib/shared';
+    import { filledSigsheet, gdrive_folder_id, uuid } from '$lib/shared';
     import { writable } from 'svelte/store';
 
     const { member_id, name, role, closeModal, activeCategory } = $props();
@@ -76,6 +76,7 @@
 
     <form class="grid gap-6 md:grid-cols-2 md:gap-0" onsubmit={handleSubmit}>
         <input type="text" alt="uuid" id="uuid-input" name="uuid" value={$uuid} hidden required />
+        <input type="text" alt="gdrive_folder_id" id="gdrive_folder_id-input" name="gdrive_folder_id" value={$gdrive_folder_id} hidden required />
 
         <input type="text" alt="member_id" id="memberid-input" name="member_id" value={member_id} hidden required />
 


### PR DESCRIPTION
This PR fully addresses Issue #35, and a lot more.

I added a new table to Supabase called `pic-folders`. This simply associates `applicant_uuid`s with a Google Drive Folder ID. 

Upon login, `/api/get_gdrive_folder` will check if the `applicant_uuid` has a folder in `pic-folders`. If there is none, a new folder will be created for the applicant. This new folder will be where all their mem-app selfies will be uploaded.

I also made it so that the name of the picture file will be App-Mem.

On a side note, I hardcoded the order of the sigsheet progress bars in the Dashboard. Previously, it was dependent on the order of which committees showed up first in the `members` table on Supabase. 