### PR TITLE
fix(NavBar): increase increase z-index

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,7 +23,7 @@
 {#if !data.session}
     {@render children()}
 {:else}
-    <header class="bg-csi-black sticky top-0 flex w-full items-center px-16 py-4">
+    <header class="bg-csi-black sticky top-0 z-50 flex w-full items-center px-16 py-4">
         <button
             class="cursor-pointer"
             onclick={() => {

--- a/src/routes/sigsheet/Modal.svelte
+++ b/src/routes/sigsheet/Modal.svelte
@@ -129,6 +129,7 @@
                     name="image"
                     onchange={handleFileChange}
                     hidden
+                    required
                 />
                 <div class="items-center" id="img-view">
                     {#if $imageURL}


### PR DESCRIPTION
This addresses Issues #42 and #43.

I simply increased the `z-index` of the `header`, so that no other elements could appear *on top* of it.