### PR TITLE
Correctly show constiquiz progress in dashboard for issue #29

### DIFF
--- a/src/routes/consti-quiz/+page.svelte
+++ b/src/routes/consti-quiz/+page.svelte
@@ -7,6 +7,9 @@
     import RadioQuestion from './RadioQuestion.svelte';
     import SectionNav from './SectionNav.svelte';
     import ShortTextQuestion from './ShortTextQuestion.svelte';
+    import { onMount } from 'svelte';
+    
+    
 
     // Supabase client
     const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY);
@@ -19,6 +22,7 @@
     // State variables for messages
     let submissionError = $state('');
     let submissionSuccess = $state('');
+    let applicantId: string | null = null;
 
     // not used
     const mv1 = $state('');
@@ -109,6 +113,17 @@
             submissionError = '';
         }
     }
+
+    onMount(() => {
+        applicantId = data?.uuid ?? null;
+
+        if (!applicantId) {
+        console.error('No UUID found.');
+        } else {
+        console.log(' applicantId:', data.uuid);
+        }
+    });
+    
 </script>
 
 <div class="flex h-screen bg-[#161619] text-[#F9FAFB]">


### PR DESCRIPTION
Fix for issue #29 

Instead of the hardcoded text and progress bar, this fix should should now indicate how many questions of the constitution quiz the user has already filled by getting the number of answered questions by the user from the _constiquiz-answers_ table from Supabase.

<img width="1919" height="1032" alt="Screenshot 2025-09-15 225408" src="https://github.com/user-attachments/assets/b3763f19-b9fa-4b35-ab5d-c66f4e4164ad" />
