### PR TITLE
feat(sigsheet): Co-Applicant category

### DIFF
--- a/src/routes/sigsheet/MemberGrid.svelte
+++ b/src/routes/sigsheet/MemberGrid.svelte
@@ -42,6 +42,19 @@
         selectedMember = member;
     }
 
+    let coApp_obj = {
+        member_id: 0,
+        name: "",
+        role: "",
+        category: "CoApp",
+        photo: "",
+    };
+
+    function openCoAppModal() {
+        selectedMember = coApp_obj;
+        showModal = true;
+    }
+
     function closeModal() {
         showModal = false;
     }
@@ -58,6 +71,7 @@
     </h1>
 
     <div class="flex flex-col-reverse gap-3 min-[375px]:gap-4 min-[390px]:gap-6 min-[834px]:flex-row">
+        {#if activeCategory !== "CoApp"}
         <div
             class="grid w-full grid-cols-2 gap-1.5 min-[375px]:gap-3 min-[390px]:gap-4 min-[480px]:grid-cols-4 min-[834px]:flex-1 min-[834px]:grid-cols-4 min-[834px]:gap-4 min-[1280px]:grid-cols-4"
         >
@@ -95,6 +109,7 @@
                 class:opacity-100={activeCategory === "CoApp"}
                 class:bg-transparent={activeCategory === "CoApp"}
                 style:border-color={activeCategory === "CoApp" ? categoryColors["CoApp"] : '#2C2C2E'}
+                onclick={() => {activeCategory = "CoApp"; openCoAppModal();}}
             >
                 <span
                     class="bg-mni-pink aspect-square w-[1.5rem] flex-shrink-0 rounded-full min-[390px]:w-[1.5rem]"
@@ -104,6 +119,7 @@
             </button>
 
         </div>
+        {/if}
     </div>
     {#if showModal}
         <div class="flex-center fixed inset-0 justify-center bg-black/50">

--- a/src/routes/sigsheet/MemberGrid.svelte
+++ b/src/routes/sigsheet/MemberGrid.svelte
@@ -19,6 +19,7 @@
         Engg: 'var(--color-engg-blue)',
         Exte: 'var(--color-exte-blue)',
         'B&C': 'var(--color-bnc-green)',
+        CoApp: 'var(--color-csi-white)',
     };
 
     const categoryHeaders: Record<string, string> = {
@@ -29,6 +30,7 @@
         Engg: 'Engineering Committee',
         Exte: 'External Relations Committee',
         'B&C': 'Branding & Creatives Committee',
+        CoApp: 'Co-Applicant',
     };
 
     let activeCategory = $state('Exec');
@@ -86,6 +88,21 @@
                     <span class="flex items-center">{category}</span>
                 </button>
             {/each}
+
+            <button
+                class="border-csi-black text-csi-white bg-csi-grey flex w-fit cursor-pointer items-center gap-2 rounded-full border-2 border-[#2C2C2E] px-[0.8rem] py-2 text-sm font-bold opacity-80 transition-colors duration-300 min-[390px]:gap-2 min-[390px]:px-[0.7rem] min-[390px]:py-1.5 min-[390px]:text-sm min-[640px]:px-[0.9rem] min-[640px]:py-2 min-[640px]:text-base"
+                aria-label="co-app sigsheet"
+                class:opacity-100={activeCategory === "CoApp"}
+                class:bg-transparent={activeCategory === "CoApp"}
+                style:border-color={activeCategory === "CoApp" ? categoryColors["CoApp"] : '#2C2C2E'}
+            >
+                <span
+                    class="bg-mni-pink aspect-square w-[1.5rem] flex-shrink-0 rounded-full min-[390px]:w-[1.5rem]"
+                    style:background-color={categoryColors["CoApp"]}
+                ></span>
+                <span class="flex items-center">Co-App</span>
+            </button>
+
         </div>
     </div>
     {#if showModal}

--- a/src/routes/sigsheet/MemberGrid.svelte
+++ b/src/routes/sigsheet/MemberGrid.svelte
@@ -57,6 +57,9 @@
 
     function closeModal() {
         showModal = false;
+        if (activeCategory === "CoApp") {
+            activeCategory = "Exec";
+        }
     }
 </script>
 

--- a/src/routes/sigsheet/MemberGrid.svelte
+++ b/src/routes/sigsheet/MemberGrid.svelte
@@ -42,12 +42,12 @@
         selectedMember = member;
     }
 
-    let coApp_obj = {
+    const coApp_obj = {
         member_id: 0,
-        name: "",
-        role: "",
-        category: "CoApp",
-        photo: "",
+        name: '',
+        role: '',
+        category: 'CoApp',
+        photo: '',
     };
 
     function openCoAppModal() {
@@ -57,8 +57,8 @@
 
     function closeModal() {
         showModal = false;
-        if (activeCategory === "CoApp") {
-            activeCategory = "Exec";
+        if (activeCategory === 'CoApp') {
+            activeCategory = 'Exec';
         }
     }
 </script>
@@ -74,54 +74,56 @@
     </h1>
 
     <div class="flex flex-col-reverse gap-3 min-[375px]:gap-4 min-[390px]:gap-6 min-[834px]:flex-row">
-        {#if activeCategory !== "CoApp"}
-        <div
-            class="grid w-full grid-cols-2 gap-1.5 min-[375px]:gap-3 min-[390px]:gap-4 min-[480px]:grid-cols-4 min-[834px]:flex-1 min-[834px]:grid-cols-4 min-[834px]:gap-4 min-[1280px]:grid-cols-4"
-        >
-            {#each members.filter(member => member.category === activeCategory) as member (member.name)}
-                <div in:fade={{ duration: 1300 }}>
-                    <button onclick={() => openModal(member)} class="w-full cursor-pointer">
-                        <MemberCard filled={$filledSigsheet.has(member.member_id)} {member} />
-                    </button>
-                </div>
-            {/each}
-        </div>
+        {#if activeCategory !== 'CoApp'}
+            <div
+                class="grid w-full grid-cols-2 gap-1.5 min-[375px]:gap-3 min-[390px]:gap-4 min-[480px]:grid-cols-4 min-[834px]:flex-1 min-[834px]:grid-cols-4 min-[834px]:gap-4 min-[1280px]:grid-cols-4"
+            >
+                {#each members.filter(member => member.category === activeCategory) as member (member.name)}
+                    <div in:fade={{ duration: 1300 }}>
+                        <button onclick={() => openModal(member)} class="w-full cursor-pointer">
+                            <MemberCard filled={$filledSigsheet.has(member.member_id)} {member} />
+                        </button>
+                    </div>
+                {/each}
+            </div>
 
-        <div
-            class="flex flex-row flex-wrap justify-start gap-1 min-[375px]:gap-1.5 min-[390px]:gap-2 min-[834px]:ml-8 min-[834px]:flex-col min-[834px]:items-start min-[834px]:gap-4"
-        >
-            {#each categories as category}
+            <div
+                class="flex flex-row flex-wrap justify-start gap-1 min-[375px]:gap-1.5 min-[390px]:gap-2 min-[834px]:ml-8 min-[834px]:flex-col min-[834px]:items-start min-[834px]:gap-4"
+            >
+                {#each categories as category}
+                    <button
+                        class="border-csi-black text-csi-white bg-csi-grey flex w-fit cursor-pointer items-center gap-2 rounded-full border-2 border-[#2C2C2E] px-[0.8rem] py-2 text-sm font-bold opacity-80 transition-colors duration-300 min-[390px]:gap-2 min-[390px]:px-[0.7rem] min-[390px]:py-1.5 min-[390px]:text-sm min-[640px]:px-[0.9rem] min-[640px]:py-2 min-[640px]:text-base"
+                        class:opacity-100={activeCategory === category}
+                        class:bg-transparent={activeCategory === category}
+                        style:border-color={activeCategory === category ? categoryColors[category] : '#2C2C2E'}
+                        onclick={() => (activeCategory = category)}
+                    >
+                        <span
+                            class="bg-mni-pink aspect-square w-[1.5rem] flex-shrink-0 rounded-full min-[390px]:w-[1.5rem]"
+                            style:background-color={categoryColors[category]}
+                        ></span>
+                        <span class="flex items-center">{category}</span>
+                    </button>
+                {/each}
+
                 <button
                     class="border-csi-black text-csi-white bg-csi-grey flex w-fit cursor-pointer items-center gap-2 rounded-full border-2 border-[#2C2C2E] px-[0.8rem] py-2 text-sm font-bold opacity-80 transition-colors duration-300 min-[390px]:gap-2 min-[390px]:px-[0.7rem] min-[390px]:py-1.5 min-[390px]:text-sm min-[640px]:px-[0.9rem] min-[640px]:py-2 min-[640px]:text-base"
-                    class:opacity-100={activeCategory === category}
-                    class:bg-transparent={activeCategory === category}
-                    style:border-color={activeCategory === category ? categoryColors[category] : '#2C2C2E'}
-                    onclick={() => (activeCategory = category)}
+                    aria-label="co-app sigsheet"
+                    class:opacity-100={activeCategory === 'CoApp'}
+                    class:bg-transparent={activeCategory === 'CoApp'}
+                    style:border-color={activeCategory === 'CoApp' ? categoryColors.CoApp : '#2C2C2E'}
+                    onclick={() => {
+                        activeCategory = 'CoApp';
+                        openCoAppModal();
+                    }}
                 >
                     <span
                         class="bg-mni-pink aspect-square w-[1.5rem] flex-shrink-0 rounded-full min-[390px]:w-[1.5rem]"
-                        style:background-color={categoryColors[category]}
+                        style:background-color={categoryColors.CoApp}
                     ></span>
-                    <span class="flex items-center">{category}</span>
+                    <span class="flex items-center">Co-App</span>
                 </button>
-            {/each}
-
-            <button
-                class="border-csi-black text-csi-white bg-csi-grey flex w-fit cursor-pointer items-center gap-2 rounded-full border-2 border-[#2C2C2E] px-[0.8rem] py-2 text-sm font-bold opacity-80 transition-colors duration-300 min-[390px]:gap-2 min-[390px]:px-[0.7rem] min-[390px]:py-1.5 min-[390px]:text-sm min-[640px]:px-[0.9rem] min-[640px]:py-2 min-[640px]:text-base"
-                aria-label="co-app sigsheet"
-                class:opacity-100={activeCategory === "CoApp"}
-                class:bg-transparent={activeCategory === "CoApp"}
-                style:border-color={activeCategory === "CoApp" ? categoryColors["CoApp"] : '#2C2C2E'}
-                onclick={() => {activeCategory = "CoApp"; openCoAppModal();}}
-            >
-                <span
-                    class="bg-mni-pink aspect-square w-[1.5rem] flex-shrink-0 rounded-full min-[390px]:w-[1.5rem]"
-                    style:background-color={categoryColors["CoApp"]}
-                ></span>
-                <span class="flex items-center">Co-App</span>
-            </button>
-
-        </div>
+            </div>
         {/if}
     </div>
     {#if showModal}

--- a/src/routes/sigsheet/Modal.svelte
+++ b/src/routes/sigsheet/Modal.svelte
@@ -94,7 +94,7 @@
 
             <!-- Left column -->
             <div class="mx-2">
-                {#if activeCategory !== "CoApp"}
+                {#if activeCategory !== 'CoApp'}
                     <h2 class="pb-1 text-2xl font-bold md:text-4xl" style="color:{categoryColors[activeCategory]}">
                         {name}
                     </h2>

--- a/src/routes/sigsheet/Modal.svelte
+++ b/src/routes/sigsheet/Modal.svelte
@@ -89,17 +89,31 @@
         <form class="grid grid-cols-1 gap-6 md:grid-cols-2" onsubmit={handleSubmit}>
             <!-- hidden inputs -->
             <input type="text" name="gdrive_folder_id" value={$gdrive_folder_id} hidden required />
-            <input type="text" name="member_id" value={member_id} hidden required />
-            <input type="text" name="member_name" value={name} hidden required />
             <input type="text" name="username" value={$username} hidden required />
             <input type="text" name="uuid" value={$uuid} hidden required />
 
             <!-- Left column -->
             <div class="mx-2">
-                <h2 class="pb-1 text-2xl font-bold md:text-4xl" style="color:{categoryColors[activeCategory]}">
-                    {name}
-                </h2>
-                <h3 class="text-csi-white text-sm">{role}</h3>
+                {#if activeCategory !== "CoApp"}
+                    <h2 class="pb-1 text-2xl font-bold md:text-4xl" style="color:{categoryColors[activeCategory]}">
+                        {name}
+                    </h2>
+                    <h3 class="text-csi-white text-sm">{role}</h3>
+                    <input type="text" name="member_id" value={member_id} hidden required />
+                    <input type="text" name="member_name" value={name} hidden required />
+                {:else}
+                    <label for="member_name" class="text-csi-white mb-1 block text-lg font-bold md:text-2xl">
+                        Co-App Name
+                    </label>
+                    <input
+                        id="member_name"
+                        name="member_name"
+                        class="text-csi-white mb-3 w-full rounded-xl bg-[#161619] px-4 py-2 text-sm font-light"
+                        placeholder="Type co-applicant's name here"
+                        style="height: 25px; resize: none"
+                        required
+                    />
+                {/if}
 
                 <label for="question" class="text-csi-white mb-1 block pt-5 text-lg font-bold md:text-2xl">
                     Your Question


### PR DESCRIPTION
This PR makes the sigsheet support Co-Applicants. 

- There is a new Co-Applicant selection button in the MemberGrid.
- Once Co-Applicant is selected, the MemberGrid will be hidden, and a modal will appear.
- The Co-Applicant Modal is similar to the member modal, but it asks for the co-applicant's name as an input.
- To represent an applicant-applicant entry in the sigsheet table in the database, foreign key `member_id` will be `NULL` for that entry.