### PR TITLE
fix(sigsheet): disable users from accessing sigsheet if not logged in

### DIFF
--- a/src/routes/sigsheet/+page.server.js
+++ b/src/routes/sigsheet/+page.server.js
@@ -1,0 +1,18 @@
+export async function load({ locals }) {
+    const { supabase } = locals;
+    const { user } = await locals.safeGetSession();
+
+    if (!user) {
+        throw new Error('Failed to load user');
+    }
+
+    const { data, error } = await supabase.from('constiquiz-submissions').select('*').eq('user_id', user.id);
+
+    if (error) {
+        console.error(error);
+    }
+
+    const hasSubmitted = data && data.length;
+
+    return { hasSubmitted };
+}


### PR DESCRIPTION
I simply copy and pasted `consti-quiz/+page.server.js` to raise an error if sigsheet page is being accessed without logging in yet.